### PR TITLE
Unity GUI scaling

### DIFF
--- a/Assets/Baracuda/Monitoring.UI/IMGUI/Prefabs/MonitoringUIController_IMGUI.prefab
+++ b/Assets/Baracuda/Monitoring.UI/IMGUI/Prefabs/MonitoringUIController_IMGUI.prefab
@@ -54,5 +54,7 @@ MonoBehaviour:
     bot: 0
     left: 5
     right: 5
+  overrideScale: 0
+  scale: 1
   backgroundColor: {r: 0, g: 0, b: 0, a: 0.8235294}
   logStartMessage: 1


### PR DESCRIPTION
Added Unity GUI scaling that will set the default scale to current UI Scaling in Preferences (`EditorGUIUtility.pixelsPerPoint`) or can be overridden through the inspector