### PR TITLE
Allow updating monitors even when Time.timeScale is below 0.05

### DIFF
--- a/Editor/MonitoringSettingsInspector.cs
+++ b/Editor/MonitoringSettingsInspector.cs
@@ -28,6 +28,7 @@ namespace Baracuda.Monitoring.Editor
         private UnityEditor.SerializedProperty _enableMonitoring;
         private UnityEditor.SerializedProperty _openDisplayOnLoad;
         private UnityEditor.SerializedProperty _asyncProfiling;
+        private UnityEditor.SerializedProperty _updatesWithLowTimeScale;
         private UnityEditor.SerializedProperty _monitoringUIOverride;
         private UnityEditor.SerializedProperty _allowMultipleUIInstances;
 
@@ -151,6 +152,7 @@ namespace Baracuda.Monitoring.Editor
                 UnityEditor.EditorGUILayout.PropertyField(_enableMonitoring);
                 UnityEditor.EditorGUILayout.PropertyField(_asyncProfiling,
                     new GUIContent("Multi Thread Profiling", _asyncProfiling.tooltip));
+                UnityEditor.EditorGUILayout.PropertyField(_updatesWithLowTimeScale);
                 UnityEditor.EditorGUILayout.Space();
 
                 UnityEditor.EditorGUILayout.PropertyField(_openDisplayOnLoad,

--- a/Runtime/Scripts/Core/Dummy/MonitoringDummy.cs
+++ b/Runtime/Scripts/Core/Dummy/MonitoringDummy.cs
@@ -147,6 +147,7 @@ namespace Baracuda.Monitoring.Dummy
         public bool IsEditorOnly { get; } = false;
         public bool AllowMultipleUIInstances { get; } = false;
         public bool AsyncProfiling { get; } = false;
+        public bool UpdatesWithLowTimeScale { get; } = false;
         public bool OpenDisplayOnLoad { get; } = false;
         public bool ShowRuntimeMonitoringObject { get; } = false;
         public LoggingLevel LogBadImageFormatException { get; } = LoggingLevel.None;

--- a/Runtime/Scripts/Core/Systems/MonitoringSettings.cs
+++ b/Runtime/Scripts/Core/Systems/MonitoringSettings.cs
@@ -21,6 +21,10 @@ namespace Baracuda.Monitoring.Systems
             "When enabled, initial profiling will be processed asynchronous on a background thread. (Disabled for WebGL)")]
         [SerializeField] private bool asyncProfiling = true;
 
+        [Tooltip(
+            "When enabled, monitoring is updated even if Time.timeScale is below 0.05")]
+        [SerializeField] private bool updatesWithLowTimeScale = false;
+        
         [Tooltip("When enabled, the monitoring display will be opened as soon as profiling has completed.")]
         [SerializeField] private bool openDisplayOnLoad = true;
 
@@ -320,6 +324,9 @@ namespace Baracuda.Monitoring.Systems
             false;
 #endif
 
+        /// <inheritdoc />
+        public bool UpdatesWithLowTimeScale => updatesWithLowTimeScale;
+        
         /*
          * UI Controller
          */

--- a/Runtime/Scripts/Core/Systems/MonitoringUpdateEvents.cs
+++ b/Runtime/Scripts/Core/Systems/MonitoringUpdateEvents.cs
@@ -67,7 +67,7 @@ namespace Baracuda.Monitoring.Systems
             }
 
             updateTimer += deltaTime;
-            if (updateTimer <= .05f)
+            if (!MonitoringSettings.Singleton.UpdatesWithLowTimeScale && updateTimer <= .05f)
             {
                 return;
             }

--- a/Runtime/Scripts/Interfaces/IMonitoringSettings.cs
+++ b/Runtime/Scripts/Interfaces/IMonitoringSettings.cs
@@ -32,6 +32,11 @@ namespace Baracuda.Monitoring
         bool AsyncProfiling { get; }
 
         /// <summary>
+        /// When enabled, monitoring is updated even if Time.timeScale is below 0.05
+        /// </summary>
+        bool UpdatesWithLowTimeScale { get;  }
+        
+        /// <summary>
         /// When enabled, the monitoring display will be opened as soon as profiling has completed.
         /// </summary>
         bool OpenDisplayOnLoad { get; }


### PR DESCRIPTION
In our games, we set Time.timeScale to 0 to handle pauses. However, in these situations, that makes your tool unusable as nothing is updated anymore. I've added a new setting and updated the code.