### PR TITLE
Suppress expensive runtime reflection if defined DISABLE_MONITORING

### DIFF
--- a/Runtime/Scripts/Monitor.cs
+++ b/Runtime/Scripts/Monitor.cs
@@ -126,13 +126,12 @@ namespace Baracuda.Monitoring
             }
         }
 
-#if !DISABLE_MONITORING
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
-#endif
         private static async void Initialize()
         {
             Construct();
 
+#if !DISABLE_MONITORING
             if (Settings == null)
             {
                 Debug.Log(SettingsNotFoundMessage);
@@ -144,6 +143,7 @@ namespace Baracuda.Monitoring
                 var profiler = new MonitoringProfiler();
                 Initialized = await profiler.ProfileAsync();
             }
+#endif
         }
 
         private static void OnApplicationQuit()

--- a/Runtime/Scripts/Monitor.cs
+++ b/Runtime/Scripts/Monitor.cs
@@ -126,7 +126,9 @@ namespace Baracuda.Monitoring
             }
         }
 
+#if !DISABLE_MONITORING
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
+#endif
         private static async void Initialize()
         {
             Construct();


### PR DESCRIPTION
#34 

MonitoringProfiler.ProfileAsync is extremely costly. This pr modified it so that it does not execute when the DISABLE_MONITORING flag is present.