### PR TITLE
Suppress runtime reflection through code generation

### DIFF
--- a/Editor/IL2CPPBuildPreprocessor.cs
+++ b/Editor/IL2CPPBuildPreprocessor.cs
@@ -734,6 +734,7 @@ namespace Baracuda.Monitoring.Editor
             stringBuilder.AppendLine("    [UnityEngine.Scripting.Preserve]");
             stringBuilder.AppendLine("    public static class GeneratedMonitoringProfilerTarget");
             stringBuilder.AppendLine("    {");
+            stringBuilder.AppendLine("        [UnityEngine.Scripting.Preserve]");
             stringBuilder.AppendLine("        public static readonly System.Type[] Types =");
             stringBuilder.AppendLine("        {");
             foreach (var targetType in targetTypes)

--- a/Editor/IL2CPPBuildPreprocessor.cs
+++ b/Editor/IL2CPPBuildPreprocessor.cs
@@ -731,10 +731,10 @@ namespace Baracuda.Monitoring.Editor
         {
             stringBuilder.AppendLine("namespace Baracuda.Monitoring");
             stringBuilder.AppendLine("{");
-            stringBuilder.AppendLine("    [UnityEngine.Scripting.Preserve]");
+            stringBuilder.AppendLine($"    {preserveAttribute}");
             stringBuilder.AppendLine("    public static class GeneratedMonitoringProfilerTarget");
             stringBuilder.AppendLine("    {");
-            stringBuilder.AppendLine("        [UnityEngine.Scripting.Preserve]");
+            stringBuilder.AppendLine($"        {preserveAttribute}");
             stringBuilder.AppendLine("        public static readonly System.Type[] Types =");
             stringBuilder.AppendLine("        {");
             foreach (var targetType in targetTypes)
@@ -742,7 +742,7 @@ namespace Baracuda.Monitoring.Editor
                 if (targetType.Namespace != null &&
                     targetType.Namespace.StartsWith("Baracuda.Monitoring")) continue;
 
-                stringBuilder.AppendLine($"        typeof(global::{targetType.FullName}),");
+                stringBuilder.AppendLine($"            typeof(global::{targetType.FullName}),");
             }
             stringBuilder.AppendLine("        };");
             stringBuilder.AppendLine("    }");

--- a/Editor/IL2CPPBuildPreprocessor.cs
+++ b/Editor/IL2CPPBuildPreprocessor.cs
@@ -83,6 +83,7 @@ namespace Baracuda.Monitoring.Editor
         private TypeBuffer TypeDefMethodBuffer { get; } = new TypeBuffer("  [Method Definitions] ");
         private TypeBuffer TypeDefOutParameterBuffer { get; } = new TypeBuffer("  [Out Parameter Definitions] ");
         private TypeBuffer TypeDefCollectionBuffer { get; } = new TypeBuffer("  [Collection Definitions] ");
+        private HashSet<Type> targetTypes = new();
 
         private class TypeBuffer
         {
@@ -151,6 +152,7 @@ namespace Baracuda.Monitoring.Editor
         {
             Debug.Log($"[Monitoring] Generating Type Definitions for IL2CPP");
 
+            targetTypes.Clear();
             for (var i = 0; i < assemblies.Length; i++)
             {
                 ProfileAssembly(assemblies[i]);
@@ -165,7 +167,10 @@ namespace Baracuda.Monitoring.Editor
             AppendTypeDefinitions(stringBuilder);
 
             AppendCloseClass(stringBuilder);
+
             AppendIfDefEnd(stringBuilder);
+
+            AppendTypeList(stringBuilder);
 
             AppendStats(stringBuilder);
 
@@ -258,6 +263,7 @@ namespace Baracuda.Monitoring.Editor
             {
                 if (fieldInfo.GetCustomAttribute<MonitorAttribute>(true) != null)
                 {
+                    targetTypes.Add(type);
                     ProfileFieldInfo(fieldInfo);
                 }
             }
@@ -267,6 +273,7 @@ namespace Baracuda.Monitoring.Editor
             {
                 if (fieldInfo.GetCustomAttribute<MonitorAttribute>(true) != null)
                 {
+                    targetTypes.Add(type);
                     ProfileFieldInfo(fieldInfo);
                 }
             }
@@ -276,6 +283,7 @@ namespace Baracuda.Monitoring.Editor
             {
                 if (propertyInfo.GetCustomAttribute<MonitorAttribute>(true) != null)
                 {
+                    targetTypes.Add(type);
                     ProfilePropertyInfo(propertyInfo);
                 }
             }
@@ -285,6 +293,7 @@ namespace Baracuda.Monitoring.Editor
             {
                 if (propertyInfo.GetCustomAttribute<MonitorAttribute>(true) != null)
                 {
+                    targetTypes.Add(type);
                     ProfilePropertyInfo(propertyInfo);
                 }
             }
@@ -294,6 +303,7 @@ namespace Baracuda.Monitoring.Editor
             {
                 if (eventInfo.GetCustomAttribute<MonitorAttribute>(true) != null)
                 {
+                    targetTypes.Add(type);
                     ProfileEventInfo(eventInfo);
                 }
             }
@@ -303,6 +313,7 @@ namespace Baracuda.Monitoring.Editor
             {
                 if (eventInfo.GetCustomAttribute<MonitorAttribute>(true) != null)
                 {
+                    targetTypes.Add(type);
                     ProfileEventInfo(eventInfo);
                 }
             }
@@ -312,6 +323,7 @@ namespace Baracuda.Monitoring.Editor
             {
                 if (methodInfo.GetCustomAttribute<MonitorAttribute>(true) != null)
                 {
+                    targetTypes.Add(type);
                     ProfileMethodInfo(methodInfo);
                 }
             }
@@ -321,6 +333,7 @@ namespace Baracuda.Monitoring.Editor
             {
                 if (methodInfo.GetCustomAttribute<MonitorAttribute>(true) != null)
                 {
+                    targetTypes.Add(type);
                     ProfileMethodInfo(methodInfo);
                 }
             }
@@ -713,6 +726,28 @@ namespace Baracuda.Monitoring.Editor
         #endregion
 
         //--------------------------------------------------------------------------------------------------------------
+
+        private void AppendTypeList(StringBuilder stringBuilder)
+        {
+            stringBuilder.AppendLine("namespace Baracuda.Monitoring");
+            stringBuilder.AppendLine("{");
+            stringBuilder.AppendLine("    [UnityEngine.Scripting.Preserve]");
+            stringBuilder.AppendLine("    public static class GeneratedMonitoringProfilerTarget");
+            stringBuilder.AppendLine("    {");
+            stringBuilder.AppendLine("        public static readonly System.Type[] Types =");
+            stringBuilder.AppendLine("        {");
+            foreach (var targetType in targetTypes)
+            {
+                if (targetType.Namespace != null &&
+                    targetType.Namespace.StartsWith("Baracuda.Monitoring")) continue;
+
+                stringBuilder.AppendLine($"        typeof(global::{targetType.FullName}),");
+            }
+            stringBuilder.AppendLine("        };");
+            stringBuilder.AppendLine("    }");
+            stringBuilder.AppendLine();
+            stringBuilder.AppendLine("}");
+        }
 
         #region Append Definitions
 

--- a/Runtime/Scripts/Core/Systems/MonitoringProfiler.cs
+++ b/Runtime/Scripts/Core/Systems/MonitoringProfiler.cs
@@ -146,8 +146,18 @@ namespace Baracuda.Monitoring.Systems
 
         private async Task ProfileInternalAsync(CancellationToken ct)
         {
-            var types = await CreateAssemblyProfileAsync(ct);
-            await CreateMonitoringProfileAsync(types, ct);
+            var generatedType = Type.GetType("Baracura.Monitoring.GeneratedMonitoringProfilerTarget");
+            if (generatedType != null)
+            {
+                var field = generatedType.GetField("Types", BindingFlags.Static | BindingFlags.Public);
+                var value = field!.GetValue(null);
+                await CreateMonitoringProfileAsync((Type[])value, ct);
+            }
+            else
+            {
+                var types = await CreateAssemblyProfileAsync(ct);
+                await CreateMonitoringProfileAsync(types, ct);
+            }
         }
 
         /*


### PR DESCRIPTION
#34 

MonitoringProfiler.ProfileAsync currently scans all types and members in assemblies not on the block list, which is very costly.

When code generation is enabled, I have added functionality to resolve the target type via code generation.